### PR TITLE
Add platform directive for postgis image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   db:
     image: postgis/postgis:14-3.5
+    platform: linux/amd64
     restart: always
     container_name: "context_layer_PG"
     env_file:


### PR DESCRIPTION
The postgis/postgis image only publishes linux/amd64 builds. Without an explicit platform override, Docker on ARM hosts (e.g. Apple Silicon, ARM Linux, Windows on ARM) fails, e.g.:

> no matching manifest for linux/arm64/v8 in the manifest list entries: no match for platform in manifest: not found

With this change, on ARM hosts, Docker will use QEMU emulation for the amd64 image – which can affect performance, but that is the only way this image will run on those platforms.

This change has no effect on amd64 hosts, since the architecture matches.