### PR TITLE
build: Add environment variables with overridable defaults

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,10 @@ services:
     image: postgis/postgis:14-3.5
     restart: always
     container_name: "context_layer_PG"
-    env_file:
-      - .env
+    environment:
+      - POSTGRES_DB=${POSTGRES_NAME:-postgres}
+      - POSTGRES_USER=${POSTGRES_USER:-postgres}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
     ports:
       - "54321:5432"
     volumes:
@@ -39,8 +41,14 @@ services:
     ports:
       - "8000:8000"
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
+      - POSTGRES_NAME=${POSTGRES_NAME:-postgres}
+      - POSTGRES_USER=${POSTGRES_USER:-postgres}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+      - POSTGRES_HOST=db
+      - POSTGRES_PORT=5432
       - REDIS_URL=redis://redis:6379/1
     depends_on:
       db:


### PR DESCRIPTION
closes #34 

This makes the .env file optional, making startup faster for new developers.

If the .env file were required but missing, developers would see:

    service "web" refers to undefined env file ".env": stat /path/to/.env: no such file or directory

The db service lists all relevant environment variables, which will be read from .env if present, by default.

Map any POSTGRES_NAME environment variable to both POSTGRES_DB for the db service and POSTGRES_NAME for the web service.
