### PR TITLE
chore: Use DJANGO_DB_LOG_LEVEL environment variable to enable SQL logging

### DIFF
--- a/D4D_ContextLayer/settings.py
+++ b/D4D_ContextLayer/settings.py
@@ -180,6 +180,22 @@ STATIC_URL = "static/"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+    },
+    "loggers": {
+        "django.db.backends": {
+            "handlers": ["console"],
+            "level": os.getenv("DJANGO_DB_LOG_LEVEL", "WARNING"),
+        },
+    },
+}
+
 STRAWBERRY_DJANGO = {
     "FIELD_DESCRIPTION_FROM_HELP_TEXT": True,
     "TYPE_DESCRIPTION_FROM_MODEL_DOCSTRING": True,


### PR DESCRIPTION
I used this to solve various N+1 queries.

I have 3 local commits to fix those, which I haven't pushed as they will conflict with existing PRs until merged.